### PR TITLE
filter_parameter_logging in config/application.rb ausgelagert

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,7 +2,6 @@ class ApplicationController < ActionController::Base
   protect_from_forgery
 
   helper_method :current_user_session, :current_user
-  filter_parameter_logging :password, :password_confirmation
 
   before_filter :set_locale
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -37,7 +37,7 @@ module ProjectZero
     config.encoding = "utf-8"
 
     # Configure sensitive parameters which will be filtered from the log file.
-    config.filter_parameters += [:password]
+    config.filter_parameters += [:password, :password_confirmation]
   end
 end
 


### PR DESCRIPTION
Beim verwenden von project_zero hatte ich immer diese deprecation warning. Die musste weg :)

DEPRECATION WARNING: Setting filter_parameter_logging in ActionController is deprecated and has no longer effect, please set 'config.filter_parameters' in config/application.rb instead. 

Gruess Silvan
